### PR TITLE
Fix error to get assembly location in .NET 5

### DIFF
--- a/PugPdf.Core/WkHtmlToPdfDriver.cs
+++ b/PugPdf.Core/WkHtmlToPdfDriver.cs
@@ -29,10 +29,7 @@ namespace PugPdf.Core
 
         private static string GetExecutablePath()
         {
-            var assembly = Assembly.GetAssembly(typeof(WkHtmlToPdfDriver));
-
-            var assemblyFolderPath = Path.GetDirectoryName(assembly.Location);
-
+            var assemblyFolderPath = AppContext.BaseDirectory; 
             var path = Path.Combine(assemblyFolderPath, "wkhtmltopdf");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Fixes #12 

I made tests using the example in this repo, and also using my application. Both worked fine, using `-p:PublishSingleFile=true` or `-p:PublishSingleFile=false`