### PR TITLE
Including "--dpi " in the arguments.

### DIFF
--- a/PugPdf.Core/PdfPrintOptions.cs
+++ b/PugPdf.Core/PdfPrintOptions.cs
@@ -14,6 +14,7 @@ namespace PugPdf.Core
         public bool Grayscale { get; set; } = false;
         public int ImageDPI { get; set; } = 600;
         public int ImageQuality { get; set; } = 94;
+        public int DPI { get; set; } = 96;
 
         public PdfHeader Header { get; set; } = new PdfHeader();
         public PdfFooter Footer { get; set; } = new PdfFooter();
@@ -45,6 +46,7 @@ namespace PugPdf.Core
 
             switches += $"--image-dpi {ImageDPI} ";
             switches += $"--image-quality {ImageQuality} ";
+            switches += $"--dpi {DPI} ";
             switches += "--disable-smart-shrinking ";
 
             switches += Header?.GetSwitches();


### PR DESCRIPTION
This is to be able to resolve some issues WkHtmlToPdf has when rendering fonts that are small.

The default value that WkHtmlToPdf uses for dpi is 96  - so there should not be any difference for users not setting the DPI property.

The issue with WkHtmlToPdf is discussed in some answers in this SO post: https://stackoverflow.com/questions/34241932/letter-spacing-is-too-large-with-wkhtmltopdf

To show this issue and how it looks after the fix i have these two pdfs:
[dpi-96.pdf](https://github.com/pug-pelle-p/pugpdf/files/10085572/dpi-96.pdf)
[dpi-300.pdf](https://github.com/pug-pelle-p/pugpdf/files/10085573/dpi-300.pdf)

Some more files to make it even more clear:
[smallfont-original.pdf](https://github.com/pug-pelle-p/pugpdf/files/10085807/smallfont-original.pdf)
[smallfont-updated.pdf](https://github.com/pug-pelle-p/pugpdf/files/10085808/smallfont-updated.pdf)

